### PR TITLE
fix a bug of _read64

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -423,8 +423,12 @@
             for (i = 0; i < length; i += 1) {
                 let low = this._read({_read: opt._read, _length: 1});
                 let high = this._read({_read: opt._read, _length: 1});
+                let low_str = low.toString(16);
+                if (low_str.length < 8) {
+                    low_str = '0'.repeat(8 - low_str.length) + low_str;
+                }
 
-                result.push(high.toString(16) + low.toString(16));
+                result.push(high.toString(16) + low_str);
             }
 
             return length === 1 ? result[0] : result;


### PR DESCRIPTION
when low < 0x10000000, high.toString(16) + low.toString(16) leads to a wrong number.
e.g. high=1, low=1, the results is 0x11 instead of 0x100000001 which is correctly.